### PR TITLE
CodeBuildとの連携のためbuildspec.ymlを追加

### DIFF
--- a/base-ami_build.json
+++ b/base-ami_build.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "region":     "ap-northeast-1",
+    "region":     "{{env `AWS_REGION`}}",
     "source_ami": "ami-3185744e",
     "ami_name_prefix": "base-ami"
   },

--- a/base-ami_build.json
+++ b/base-ami_build.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "region":     "{{env `AWS_REGION`}}",
+    "region":     "ap-northeast-1",
     "source_ami": "ami-3185744e",
     "ami_name_prefix": "base-ami"
   },

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   pre_build:
     commands:
       - echo "HashiCorp Packer をインストール中..."
-      - curl -qL -o packer.zip https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_linux_amd64.zip && unzip packer.zip
+      - curl -qL -o packer.zip https://releases.hashicorp.com/packer/1.2.3/packer_1.2.3_linux_amd64.zip && unzip packer.zip
       - echo "jq をインストール中..."
       - curl -qL -o jq https://stedolan.github.io/jq/download/linux64/jq && chmod +x ./jq
       - echo "base-ami_build.json をバリデーションします"
@@ -16,11 +16,10 @@ phases:
       ### More info here: https://github.com/mitchellh/packer/issues/4279
       - echo "AWS credentials を設定"
       - curl -qL -o aws_credentials.json http://169.254.170.2/$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI > aws_credentials.json
-      - aws configure set region ap-northeast-1
+      - aws configure set region $AWS_REGION
       - aws configure set aws_access_key_id `./jq -r '.AccessKeyId' aws_credentials.json`
       - aws configure set aws_secret_access_key `./jq -r '.SecretAccessKey' aws_credentials.json`
       - aws configure set aws_session_token `./jq -r '.Token' aws_credentials.json`
-      - export AWS_REGION="ap-northeast-1"
       - echo "HashiCorp Packer のテンプレート base-ami_build.json をビルド"
       - ./packer build base-ami_build.json
   post_build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,27 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo "HashiCorp Packer をインストール中..."
+      - curl -qL -o packer.zip https://releases.hashicorp.com/packer/0.12.3/packer_0.12.3_linux_amd64.zip && unzip packer.zip
+      - echo "jq をインストール中..."
+      - curl -qL -o jq https://stedolan.github.io/jq/download/linux64/jq && chmod +x ./jq
+      - echo "base-ami_build.json をバリデーションします"
+      - ./packer validate base-ami_build.json
+  build:
+    commands:
+      ### HashiCorp Packer cannot currently obtain the AWS CodeBuild-assigned role and its credentials
+      ### Manually capture and configure the AWS CLI to provide HashiCorp Packer with AWS credentials
+      ### More info here: https://github.com/mitchellh/packer/issues/4279
+      - echo "AWS credentials を設定"
+      - curl -qL -o aws_credentials.json http://169.254.170.2/$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI > aws_credentials.json
+      - aws configure set region $AWS_REGION
+      - aws configure set aws_access_key_id `./jq -r '.AccessKeyId' aws_credentials.json`
+      - aws configure set aws_secret_access_key `./jq -r '.SecretAccessKey' aws_credentials.json`
+      - aws configure set aws_session_token `./jq -r '.Token' aws_credentials.json`
+      - echo "HashiCorp Packer のテンプレート base-ami_build.json をビルド"
+      - ./packer build base-ami_build.json
+  post_build:
+    commands:
+      - echo "HashiCorp Packer によるビルドが完了しました。 `date`"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,6 +20,7 @@ phases:
       - aws configure set aws_access_key_id `./jq -r '.AccessKeyId' aws_credentials.json`
       - aws configure set aws_secret_access_key `./jq -r '.SecretAccessKey' aws_credentials.json`
       - aws configure set aws_session_token `./jq -r '.Token' aws_credentials.json`
+      - export AWS_REGION="ap-northeast-1"
       - echo "HashiCorp Packer のテンプレート base-ami_build.json をビルド"
       - ./packer build base-ami_build.json
   post_build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,7 +16,7 @@ phases:
       ### More info here: https://github.com/mitchellh/packer/issues/4279
       - echo "AWS credentials を設定"
       - curl -qL -o aws_credentials.json http://169.254.170.2/$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI > aws_credentials.json
-      - aws configure set region $AWS_REGION
+      - aws configure set region ap-northeast-1
       - aws configure set aws_access_key_id `./jq -r '.AccessKeyId' aws_credentials.json`
       - aws configure set aws_secret_access_key `./jq -r '.SecretAccessKey' aws_credentials.json`
       - aws configure set aws_session_token `./jq -r '.Token' aws_credentials.json`


### PR DESCRIPTION
[AWS CodeBuildとHashiCorp Packerを用いたAMIビルダーの構築方法](https://aws.amazon.com/jp/blogs/news/how-to-create-an-ami-builder-with-aws-codebuild-and-hashicorp-packer/)
[CodeBuildでGitHubのプルリクエストを自動ビルドして、結果を表示する](https://dev.classmethod.jp/cloud/aws/codebuild-github-pullrequest-settings/)